### PR TITLE
Migrate Device ID

### DIFF
--- a/custom_components/playstation_network/entity.py
+++ b/custom_components/playstation_network/entity.py
@@ -25,12 +25,13 @@ class PSNEntity(CoordinatorEntity[PsnCoordinator]):
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
+        username = "PSN"
+        if len(self.coordinator.data.get("username")) > 0:
+            username = self.coordinator.data.get("username")
+
         return DeviceInfo(
-            identifiers={
-                # Serial numbers are unique identifiers within a specific domain
-                (DOMAIN, "PSN")
-            },
-            name="PSN",
+            identifiers={(DOMAIN, username)},
+            name=username,
             manufacturer="Sony",
             model="Playstation Network",
             configuration_url="https://ca.account.sony.com/api/v1/ssocookie",

--- a/custom_components/playstation_network/manifest.json
+++ b/custom_components/playstation_network/manifest.json
@@ -4,11 +4,12 @@
   "codeowners": ["@jackjpowell"],
   "config_flow": true,
   "dependencies": ["network"],
-  "version": "0.3.0",
   "documentation": "https://github.com/JackJPowell/hass-psn",
   "homekit": {},
   "integration_type": "device",
   "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/JackJPowell/hass-psn/issues",
   "requirements": ["PSNAWP-HA==0.1.0"],
-  "ssdp": []
+  "ssdp": [],
+  "version": "0.4.0"
 }

--- a/custom_components/playstation_network/media_player.py
+++ b/custom_components/playstation_network/media_player.py
@@ -49,6 +49,7 @@ class MediaPlayer(PSNEntity, MediaPlayerEntity):
         """Initialize PSN MediaPlayer."""
         super().__init__(coordinator)
         self.data = self.coordinator.data
+        self._attr_has_entity_name = True
 
     @property
     def icon(self):
@@ -76,7 +77,7 @@ class MediaPlayer(PSNEntity, MediaPlayerEntity):
 
     @property
     def unique_id(self):
-        return f"{self.data.get('platform').get('platform')}_console"
+        return f"{self.data.get('username')}_{self.data.get('platform').get('platform')}_console"
 
     @property
     def name(self):

--- a/custom_components/playstation_network/sensor.py
+++ b/custom_components/playstation_network/sensor.py
@@ -5,11 +5,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-    SensorEntity,
-    SensorEntityDescription,
-)
+from homeassistant.components.sensor import (SensorDeviceClass, SensorEntity,
+                                             SensorEntityDescription)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.typing import StateType
 
@@ -146,26 +143,23 @@ PSN_SENSOR: tuple[PsnSensorEntityDescription, ...] = (
     PsnSensorEntityDescription(
         key="trophy_summary",
         native_unit_of_measurement="Trophy Level",
-        suggested_unit_of_measurement="",
-        description="Your PSN Trophies",
-        name="Playstation Trophy Level",
+        name="Trophy Level",
         icon="mdi:trophy",
         entity_registry_enabled_default=True,
-        has_entity_name=False,
-        unique_id="psn_trophies",
+        has_entity_name=True,
+        unique_id="trophies",
         value_fn=lambda data: data.get("trophy_summary").trophy_level,
         attributes_fn=get_trophy_attr,
     ),
     PsnSensorEntityDescription(
         key="status",
         device_class=SensorDeviceClass.ENUM,
-        description="Your PSN Status",
-        name="PSN Status",
+        name="Status",
         icon="mdi:account-circle-outline",
         options=["Online", "Offline", "Playing"],
         entity_registry_enabled_default=True,
-        has_entity_name=False,
-        unique_id="psn_status",
+        has_entity_name=True,
+        unique_id="status",
         value_fn=get_status,
         attributes_fn=get_status_attr,
     ),
@@ -190,7 +184,8 @@ class PsnSensor(PSNEntity, SensorEntity):
     def __init__(self, coordinator, description: PsnSensorEntityDescription) -> None:
         """Initialize PSN Sensor."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"psn_{description.unique_id}"
+        self._attr_unique_id = f"{coordinator.data.get("username")}_{description.unique_id}"
+        self._attr_name = f"{description.name}"
         self.entity_description = description
         self._state = 0
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,8 +1,6 @@
 {
   "name": "Playstation Network",
-  "domains": ["media_player", "sensor", "notify"],
   "homeassistant": "2023.12.0",
-  "iot_class": "Cloud Polling",
   "render_readme": true,
   "zip_release": true,
   "filename": "psn.zip"


### PR DESCRIPTION
Adds support for migrating a device ID that was incorrectly named
Corrects Device Name
Corrects Entity ID naming