### PR TITLE
Adds migration support to device and entities

### DIFF
--- a/custom_components/playstation_network/__init__.py
+++ b/custom_components/playstation_network/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, Platform
@@ -106,14 +107,29 @@ def async_migrate_entity_entry(entry: er.RegistryEntry) -> dict[str, Any] | None
 
     - Migrates old unique ID's from old sensors and media players to the new unique ID's
     """
-    if entry.domain == Platform.SENSOR and entry.unique_id.endswith(
-        "-relative_humidity"
-    ):
+    coordinator = entry.entry_id[PSN_COORDINATOR]
+    if entry.domain == Platform.SENSOR and entry.unique_id.endswith("psn_psn_status"):
+        new = f"{coordinator.data.get("username").lower()}_psn_status"
         return {
-            "new_unique_id": entry.unique_id.replace("-relative_humidity", "-humidity")
+            "new_unique_id": entry.unique_id.replace(
+                "psn_psn_status", new
+            )
         }
-    if entry.domain == Platform.MEDIA_PLAYER and entry.unique_id.endswith("-plug"):
-        return {"new_unique_id": entry.unique_id.replace("-plug", "-relay")}
+
+    if entry.domain == Platform.SENSOR and entry.unique_id.endswith("psn_psn_trophies"):
+        new = f"{coordinator.data.get("username").lower()}_trophy_level"
+        return {
+            "new_unique_id": entry.unique_id.replace(
+                "psn_psn_trophy_level", new
+            )
+        }
+    if entry.domain == Platform.MEDIA_PLAYER and entry.unique_id.endswith("_console"):
+        new = f"{coordinator.data.get('username')}_{coordinator.data.get('platform').get('platform').lower()}_console"
+        return {
+            "new_unique_id": entry.unique_id.replace(
+                "PS5_console", new
+            )
+        }
 
     # No migration needed
     return None

--- a/custom_components/playstation_network/__init__.py
+++ b/custom_components/playstation_network/__init__.py
@@ -29,7 +29,7 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up PSN from a config entry."""
 
-    await er.async_migrate_entries(hass, entry.entry_id, async_migrate_entity_entry)
+
 
     try:
         npsso = entry.data.get("npsso")
@@ -52,6 +52,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         PSN_COORDINATOR: coordinator,
         PSN_API: psn,
     }
+    await er.async_migrate_entries(hass, entry.entry_id, async_migrate_entity_entry)
     if entry.unique_id is None:
         hass.config_entries.async_update_entry(entry, unique_id=user.online_id)
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/playstation_network/__init__.py
+++ b/custom_components/playstation_network/__init__.py
@@ -82,14 +82,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             }
 
         if entry.domain == Platform.SENSOR and entry.unique_id.endswith("psn_psn_trophies"):
-            new = f"{coordinator.data.get("username").lower()}_trophy_level"
+            new = f"{coordinator.data.get("username").lower()}_psn_trophy_level"
             return {
                 "new_unique_id": entry.unique_id.replace(
-                    "psn_psn_trophy_level", new
+                    "psn_psn_trophies", new
                 )
             }
-        if entry.domain == Platform.MEDIA_PLAYER and entry.unique_id.endswith("_console"):
-            new = f"{coordinator.data.get('username')}_{coordinator.data.get('platform').get('platform').lower()}_console"
+        if entry.domain == Platform.MEDIA_PLAYER and entry.unique_id is "PS5_console":
+            new = f"{coordinator.data.get('username').lower()}_{coordinator.data.get('platform').get('platform').lower()}_console"
             return {
                 "new_unique_id": entry.unique_id.replace(
                     "PS5_console", new

--- a/custom_components/playstation_network/__init__.py
+++ b/custom_components/playstation_network/__init__.py
@@ -88,7 +88,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     "psn_psn_trophies", new
                 )
             }
-        if entry.domain == Platform.MEDIA_PLAYER and entry.unique_id is "PS5_console":
+        if entry.domain == Platform.MEDIA_PLAYER and entry.unique_id == "PS5_console":
             new = f"{coordinator.data.get('username').lower()}_{coordinator.data.get('platform').get('platform').lower()}_console"
             return {
                 "new_unique_id": entry.unique_id.replace(

--- a/custom_components/playstation_network/media_player.py
+++ b/custom_components/playstation_network/media_player.py
@@ -36,7 +36,15 @@ async def async_setup_entry(
 ) -> None:
     """Entity Setup"""
     coordinator = hass.data[DOMAIN][config_entry.entry_id][PSN_COORDINATOR]
-    await coordinator.async_config_entry_first_refresh()
+
+    if coordinator.data.get("platform").get("platform") is None:
+        username = coordinator.data.get("username")
+        _LOGGER.warning(
+            "No console found associated with account: %s. -- Skipping creation of media player",
+            username,
+        )
+        return
+
     async_add_entities([MediaPlayer(coordinator)])
 
 

--- a/custom_components/playstation_network/media_player.py
+++ b/custom_components/playstation_network/media_player.py
@@ -77,7 +77,7 @@ class MediaPlayer(PSNEntity, MediaPlayerEntity):
 
     @property
     def unique_id(self):
-        return f"{self.data.get('username')}_{self.data.get('platform').get('platform').lower()}_console"
+        return f"{self.data.get('username').lower()}_{self.data.get('platform').get('platform').lower()}_console"
 
     @property
     def name(self):

--- a/custom_components/playstation_network/media_player.py
+++ b/custom_components/playstation_network/media_player.py
@@ -76,8 +76,8 @@ class MediaPlayer(PSNEntity, MediaPlayerEntity):
                 return MediaPlayerState.OFF
 
     @property
-    def unique_id(self):
-        return f"{self.data.get('username')}_{self.data.get('platform').get('platform')}_console"
+    def entity_id(self):
+        return f"{DOMAIN}.{self.data.get('username')}_{self.data.get('platform').get('platform')}_console"
 
     @property
     def name(self):

--- a/custom_components/playstation_network/media_player.py
+++ b/custom_components/playstation_network/media_player.py
@@ -50,7 +50,6 @@ class MediaPlayer(PSNEntity, MediaPlayerEntity):
         super().__init__(coordinator)
         self.data = self.coordinator.data
         self._attr_has_entity_name = True
-        self.entity_id = f"media_player.{self.data.get('username').lower()}_{self.data.get('platform').get('platform').lower()}_console"
 
     @property
     def icon(self):
@@ -76,9 +75,9 @@ class MediaPlayer(PSNEntity, MediaPlayerEntity):
             case _:
                 return MediaPlayerState.OFF
 
-    # @property
-    # def entity_id(self):
-    #     return f"media_player.{self.data.get('username').lower()}_{self.data.get('platform').get('platform').lower()}_console"
+    @property
+    def unique_id(self):
+        return f"{self.data.get('username')}_{self.data.get('platform').get('platform')}_console"
 
     @property
     def name(self):

--- a/custom_components/playstation_network/media_player.py
+++ b/custom_components/playstation_network/media_player.py
@@ -50,6 +50,7 @@ class MediaPlayer(PSNEntity, MediaPlayerEntity):
         super().__init__(coordinator)
         self.data = self.coordinator.data
         self._attr_has_entity_name = True
+        self.entity_id = f"media_player.{self.data.get('username').lower()}_{self.data.get('platform').get('platform').lower()}_console"
 
     @property
     def icon(self):
@@ -75,9 +76,9 @@ class MediaPlayer(PSNEntity, MediaPlayerEntity):
             case _:
                 return MediaPlayerState.OFF
 
-    @property
-    def entity_id(self):
-        return f"{DOMAIN}.{self.data.get('username')}_{self.data.get('platform').get('platform')}_console"
+    # @property
+    # def entity_id(self):
+    #     return f"media_player.{self.data.get('username').lower()}_{self.data.get('platform').get('platform').lower()}_console"
 
     @property
     def name(self):

--- a/custom_components/playstation_network/media_player.py
+++ b/custom_components/playstation_network/media_player.py
@@ -77,7 +77,7 @@ class MediaPlayer(PSNEntity, MediaPlayerEntity):
 
     @property
     def unique_id(self):
-        return f"{self.data.get('username')}_{self.data.get('platform').get('platform')}_console"
+        return f"{self.data.get('username')}_{self.data.get('platform').get('platform').lower()}_console"
 
     @property
     def name(self):

--- a/custom_components/playstation_network/sensor.py
+++ b/custom_components/playstation_network/sensor.py
@@ -146,8 +146,8 @@ PSN_SENSOR: tuple[PsnSensorEntityDescription, ...] = (
         name="Trophy Level",
         icon="mdi:trophy",
         entity_registry_enabled_default=True,
-        has_entity_name=False,
-        unique_id="psn_trophies",
+        has_entity_name=True,
+        unique_id="trophies",
         value_fn=lambda data: data.get("trophy_summary").trophy_level,
         attributes_fn=get_trophy_attr,
     ),
@@ -158,8 +158,8 @@ PSN_SENSOR: tuple[PsnSensorEntityDescription, ...] = (
         icon="mdi:account-circle-outline",
         options=["Online", "Offline", "Playing"],
         entity_registry_enabled_default=True,
-        has_entity_name=False,
-        unique_id="psn_status",
+        has_entity_name=True,
+        unique_id="status",
         value_fn=get_status,
         attributes_fn=get_status_attr,
     ),
@@ -184,8 +184,9 @@ class PsnSensor(PSNEntity, SensorEntity):
     def __init__(self, coordinator, description: PsnSensorEntityDescription) -> None:
         """Initialize PSN Sensor."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.data.get("username")}_{description.unique_id}"
-        self._attr_unique_id = f"psn_{description.unique_id}"
+        self.entity_id = f"{DOMAIN}.{coordinator.data.get("username")}_{description.unique_id}"
+        #self._attr_unique_id = f"{coordinator.data.get("username")}_{description.unique_id}"
+        # self._attr_unique_id = f"psn_{description.unique_id}"
         self._attr_name = f"{description.name}"
         self.entity_description = description
         self._state = 0

--- a/custom_components/playstation_network/sensor.py
+++ b/custom_components/playstation_network/sensor.py
@@ -146,8 +146,8 @@ PSN_SENSOR: tuple[PsnSensorEntityDescription, ...] = (
         name="Trophy Level",
         icon="mdi:trophy",
         entity_registry_enabled_default=True,
-        has_entity_name=True,
-        unique_id="trophies",
+        has_entity_name=False,
+        unique_id="psn_trophies",
         value_fn=lambda data: data.get("trophy_summary").trophy_level,
         attributes_fn=get_trophy_attr,
     ),
@@ -158,8 +158,8 @@ PSN_SENSOR: tuple[PsnSensorEntityDescription, ...] = (
         icon="mdi:account-circle-outline",
         options=["Online", "Offline", "Playing"],
         entity_registry_enabled_default=True,
-        has_entity_name=True,
-        unique_id="status",
+        has_entity_name=False,
+        unique_id="psn_status",
         value_fn=get_status,
         attributes_fn=get_status_attr,
     ),
@@ -185,6 +185,7 @@ class PsnSensor(PSNEntity, SensorEntity):
         """Initialize PSN Sensor."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{coordinator.data.get("username")}_{description.unique_id}"
+        self._attr_unique_id = f"psn_{description.unique_id}"
         self._attr_name = f"{description.name}"
         self.entity_description = description
         self._state = 0

--- a/custom_components/playstation_network/sensor.py
+++ b/custom_components/playstation_network/sensor.py
@@ -169,7 +169,6 @@ PSN_SENSOR: tuple[PsnSensorEntityDescription, ...] = (
 async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entities):
     """Add sensors for passed config_entry in HA."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id][PSN_COORDINATOR]
-    await coordinator.async_config_entry_first_refresh()
 
     async_add_entities(
         PsnSensor(coordinator, description) for description in PSN_SENSOR

--- a/custom_components/playstation_network/sensor.py
+++ b/custom_components/playstation_network/sensor.py
@@ -147,7 +147,7 @@ PSN_SENSOR: tuple[PsnSensorEntityDescription, ...] = (
         icon="mdi:trophy",
         entity_registry_enabled_default=True,
         has_entity_name=True,
-        unique_id="trophies",
+        unique_id="psn_trophy_level",
         value_fn=lambda data: data.get("trophy_summary").trophy_level,
         attributes_fn=get_trophy_attr,
     ),
@@ -159,7 +159,7 @@ PSN_SENSOR: tuple[PsnSensorEntityDescription, ...] = (
         options=["Online", "Offline", "Playing"],
         entity_registry_enabled_default=True,
         has_entity_name=True,
-        unique_id="status",
+        unique_id="psn_status",
         value_fn=get_status,
         attributes_fn=get_status_attr,
     ),
@@ -184,7 +184,7 @@ class PsnSensor(PSNEntity, SensorEntity):
     def __init__(self, coordinator, description: PsnSensorEntityDescription) -> None:
         """Initialize PSN Sensor."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{coordinator.data.get("username")}_{description.unique_id}"
+        self._attr_unique_id = f"{coordinator.data.get("username").lower()}_{description.unique_id}"
         self._attr_name = f"{description.name}"
         self.entity_description = description
         self._state = 0

--- a/custom_components/playstation_network/sensor.py
+++ b/custom_components/playstation_network/sensor.py
@@ -184,9 +184,7 @@ class PsnSensor(PSNEntity, SensorEntity):
     def __init__(self, coordinator, description: PsnSensorEntityDescription) -> None:
         """Initialize PSN Sensor."""
         super().__init__(coordinator)
-        self.entity_id = f"sensor.{coordinator.data.get("username").lower()}_{description.unique_id}"
-        #self._attr_unique_id = f"{coordinator.data.get("username")}_{description.unique_id}"
-        # self._attr_unique_id = f"psn_{description.unique_id}"
+        self._attr_unique_id = f"{coordinator.data.get("username")}_{description.unique_id}"
         self._attr_name = f"{description.name}"
         self.entity_description = description
         self._state = 0

--- a/custom_components/playstation_network/sensor.py
+++ b/custom_components/playstation_network/sensor.py
@@ -184,7 +184,7 @@ class PsnSensor(PSNEntity, SensorEntity):
     def __init__(self, coordinator, description: PsnSensorEntityDescription) -> None:
         """Initialize PSN Sensor."""
         super().__init__(coordinator)
-        self.entity_id = f"{DOMAIN}.{coordinator.data.get("username")}_{description.unique_id}"
+        self.entity_id = f"sensor.{coordinator.data.get("username").lower()}_{description.unique_id}"
         #self._attr_unique_id = f"{coordinator.data.get("username")}_{description.unique_id}"
         # self._attr_unique_id = f"psn_{description.unique_id}"
         self._attr_name = f"{description.name}"


### PR DESCRIPTION
Entity unique IDs will be migrated to current format making them actually unique
Device Name will now reflect PSN Account
Multiple devices (PSN Accounts) are now supported