### PR TITLE
Add individual sensors for each attribute

### DIFF
--- a/custom_components/playstation_network/translations/de.json
+++ b/custom_components/playstation_network/translations/de.json
@@ -1,0 +1,27 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Gerät ist bereits konfiguriert",
+      "already_in_progress": "Gerät wird gerade eingerichtet",
+      "reauth_successful": "Die erneute Authentifizierung war erfolgreich"
+    },
+    "error": {
+      "cannot_connect": "Verbindung fehlgeschlagen",
+      "invalid_auth": "Ungültige Authentifizierung",
+      "unknown": "Unerwarteter Fehler"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "npsso": "NPSSO-Code"
+        }
+      },
+      "reauth_confirm": {
+        "data": {
+          "npsso": "NPSSO-Code"
+        },
+        "title": "Mit neuem NPSSO-Code erneut authentifizieren"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR extends the existing integration by adding a separate sensor for each attribute, allowing all data points to be displayed individually in Home Assistant. Please note: I haven't tested these changes yet, so additional testing might be necessary.