### PR TITLE
About Me as top level sensor

### DIFF
--- a/custom_components/playstation_network/manifest.json
+++ b/custom_components/playstation_network/manifest.json
@@ -11,5 +11,5 @@
   "issue_tracker": "https://github.com/JackJPowell/hass-psn/issues",
   "requirements": ["PSNAWP-HA==2.2.2"],
   "ssdp": [],
-  "version": "0.7.0"
+  "version": "0.7.1"
 }

--- a/custom_components/playstation_network/sensor.py
+++ b/custom_components/playstation_network/sensor.py
@@ -185,6 +185,16 @@ PSN_SENSOR: tuple[PsnSensorEntityDescription, ...] = (
         unique_id="has_playstation_plus",
         value_fn=get_ps_plus_status,
     ),
+    PsnSensorEntityDescription(
+        key="about_me",
+        native_unit_of_measurement=None,
+        name="About Me",
+        icon="mdi:comment-text-outline",
+        entity_registry_enabled_default=True,
+        has_entity_name=True,
+        unique_id="about_me",
+        value_fn=lambda data: data.get("profile").get("aboutMe"),
+    ),
 )
 
 PSN_ADDITIONAL_SENSOR: tuple[PsnSensorEntityDescription, ...] = (
@@ -197,16 +207,6 @@ PSN_ADDITIONAL_SENSOR: tuple[PsnSensorEntityDescription, ...] = (
         has_entity_name=True,
         unique_id="psn_title_name_attr",
         value_fn=lambda data: data.get("name"),
-    ),
-    PsnSensorEntityDescription(
-        key="about_me",
-        native_unit_of_measurement=None,
-        name="About Me",
-        icon="mdi:information-outline",
-        entity_registry_enabled_default=True,
-        has_entity_name=True,
-        unique_id="psn_about_me_attr",
-        value_fn=lambda data: data.get("about_me"),
     ),
     PsnSensorEntityDescription(
         key="platform",


### PR DESCRIPTION
The about me sensor was trapped under the option to expose all attributes as sensors. This was a mistake and has been corrected with this pull request. 