### PR TITLE
Fix - 'NoneType' object is not callable

### DIFF
--- a/custom_components/playstation_network/sensor.py
+++ b/custom_components/playstation_network/sensor.py
@@ -108,18 +108,20 @@ def get_status_attr(coordinator_data: any) -> dict[str, str]:
         attrs["earned_trophies"] = title_trophies.earned_trophies
         attrs["trophy_progress"] = title_trophies.progress
 
+        title_stats = None
         for t in coordinator_data["recent_titles"]:
             if t.title_id == coordinator_data.get("title_metadata").get("npTitleId"):
                 title_stats = t
                 break
 
-        attrs["play_count"] = title_stats.play_count
+        if title_stats:
+            attrs["play_count"] = title_stats.play_count
 
-        formatted_duration, hours_duration = convert_time(
-            duration=title_stats.play_duration
-        )
-        attrs["play_duration"] = formatted_duration
-        attrs["play_duration_hours"] = hours_duration
+            formatted_duration, hours_duration = convert_time(
+                duration=title_stats.play_duration
+            )
+            attrs["play_duration"] = formatted_duration
+            attrs["play_duration_hours"] = hours_duration
 
     return attrs
 

--- a/custom_components/playstation_network/sensor.py
+++ b/custom_components/playstation_network/sensor.py
@@ -434,6 +434,8 @@ class PsnSensor(PSNEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, str]:
         """Return the state attributes of the entity."""
+        if self.entity_description.attributes_fn is None:
+            return {}
         if self.coordinator.data.get("title_metadata").get("npTitleId") is not None:
             return self.entity_description.attributes_fn(self.coordinator.data)
         if self.entity_description.key == "trophy_summary":


### PR DESCRIPTION
Fixing these two errors:

```
Logger: homeassistant
Zdroj: custom_components/playstation_network/sensor.py:438
integrace: Playstation Network (dokumentace, problémy)
První výskyt: 23. března 2025 v 18:23:35 (1195 výskyty)
Naposledy logováno: 19:25:19

Error doing job: Task exception was never retrieved (None)
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 268, in _handle_refresh_interval
    await self._async_refresh(log_failures=True, scheduled=True)
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 479, in _async_refresh
    self.async_update_listeners()
    ~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 178, in async_update_listeners
    update_callback()
    ~~~^^
  File "/config/custom_components/playstation_network/sensor.py", line 427, in _handle_coordinator_update
    self.async_write_ha_state()
    ~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1023, in async_write_ha_state
    self._async_write_ha_state()
    ~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1148, in _async_write_ha_state
    self.__async_calculate_state()
    ~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1089, in __async_calculate_state
    if extra_state_attributes := self.extra_state_attributes:
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/playstation_network/sensor.py", line 438, in extra_state_attributes
    return self.entity_description.attributes_fn(self.coordinator.data)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not callable
```

And this error caused by fixing the previous one:

```
Logger: homeassistant
Zdroj: custom_components/playstation_network/sensor.py:116
integrace: Playstation Network (dokumentace, problémy)
První výskyt: 20:35:01 (112 výskyty)
Naposledy logováno: 22:07:53

Error doing job: Task exception was never retrieved (None)
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 268, in _handle_refresh_interval
    await self._async_refresh(log_failures=True, scheduled=True)
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 479, in _async_refresh
    self.async_update_listeners()
    ~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 178, in async_update_listeners
    update_callback()
    ~~~^^
  File "/config/custom_components/playstation_network/sensor.py", line 427, in _handle_coordinator_update
    self.async_write_ha_state()
    ~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1023, in async_write_ha_state
    self._async_write_ha_state()
    ~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1148, in _async_write_ha_state
    self.__async_calculate_state()
    ~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1089, in __async_calculate_state
    if extra_state_attributes := self.extra_state_attributes:
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/playstation_network/sensor.py", line 440, in extra_state_attributes
    return self.entity_description.attributes_fn(self.coordinator.data)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/playstation_network/sensor.py", line 116, in get_status_attr
    attrs["play_count"] = title_stats.play_count
                          ^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'title_stats' where it is not associated with a value
```