### PR TITLE
Bump pyrate-limiter to >=3.7.0 (fixes database lock spam)

### DIFF
--- a/custom_components/playstation_network/manifest.json
+++ b/custom_components/playstation_network/manifest.json
@@ -9,7 +9,10 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/JackJPowell/hass-psn/issues",
-  "requirements": ["PSNAWP-HA==2.3.6"],
+  "requirements": [
+  "PSNAWP-HA==2.3.6",
+  "pyrate-limiter>=3.7.0"
+]
   "ssdp": [],
   "version": "0.7.4"
 }


### PR DESCRIPTION
This PR fixes a SQLite locking issue caused by pyrate-limiter 2.10.0 pulled via PSNAWP-HA.
After bumping to >=3.7.0, the log spam (`database is locked`) stops entirely.
Tested on Home Assistant OS (Python 3.13) – stable after patch.

Closes #43 
